### PR TITLE
Deploy FRE-NCtools 2025.05-1

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.05.001"
+    "spack-packages": "2025.07.002"
 }

--- a/fre-nctools/spack.yaml
+++ b/fre-nctools/spack.yaml
@@ -4,7 +4,7 @@
 # configuration settings.
 spack:
   specs:
-    - fre-nctools@2024.05
+    - fre-nctools@2024.05-1
   packages:
     fre-nctools:
       require:
@@ -24,4 +24,4 @@ spack:
         include:
           - fre-nctools
         projections:
-          fre-nctools: 'model-tools/{name}/2024.05'
+          fre-nctools: 'model-tools/{name}/2024.05-1'


### PR DESCRIPTION
There's not much more to say.

Closes #6 

---
:rocket: The latest prerelease `fre-nctools/pr7-2` at 53cd1854596f261370f06508b6f4b29726cfa446 is here: https://github.com/ACCESS-NRI/model-tools/pull/7#issuecomment-3056942433 :rocket:

