### PR TITLE
Deploy FRE-NCtools 2024.05-1

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.05.001"
+    "spack-packages": "2025.07.002"
 }

--- a/fre-nctools/spack.yaml
+++ b/fre-nctools/spack.yaml
@@ -4,7 +4,7 @@
 # configuration settings.
 spack:
   specs:
-    - fre-nctools@2024.05
+    - fre-nctools@2024.05-1
   packages:
     fre-nctools:
       require:
@@ -24,4 +24,4 @@ spack:
         include:
           - fre-nctools
         projections:
-          fre-nctools: 'model-tools/{name}/2024.05'
+          fre-nctools: 'model-tools/{name}/2024.05-1'


### PR DESCRIPTION
Reattempt at #7 because I accidentally wrote the version wrong in the commit message and only realized after merging. @CodeGat removed the commit from main and we're having another go.

See #6 for issue

---
:rocket: The latest prerelease `fre-nctools/pr8-2` at b144416ba4877011cc6179aaa3c3baccc5b4e953 is here: https://github.com/ACCESS-NRI/model-tools/pull/8#issuecomment-3060583012 :rocket:
