### PR TITLE
Deploy mppnccombine-fast 2025.07.000

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ Deployment is on to HPC targets, in this case gadi@NCI, utilising the [build-cd]
 
 ## Supported tools
 
-* `fre-nctools`: [FRE-NCtools](https://github.com/NOAA-GFDL/FRE-NCtools) is a collection of tools for creating grids and mosaics commonly used in climate and weather models, the remapping of data among grids, and the creation and manipulation of netCDF files.
+### fre-nctools
+[FRE-NCtools](https://github.com/NOAA-GFDL/FRE-NCtools) is a collection of tools for creating grids and mosaics commonly used in climate and weather models, the remapping of data among grids, and the creation and manipulation of netCDF files.
+
+### mppnccombine-fast
+[mppnccombine-fast](https://github.com/ACCESS-NRI/mppnccombine-fast) is an accelerated version of the mppnccombine post-processing tool for MOM.
 
 ## How to use
 

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.07.002"
+    "spack-packages": "2025.07.005"
 }

--- a/mppnccombine-fast/spack.yaml
+++ b/mppnccombine-fast/spack.yaml
@@ -1,0 +1,30 @@
+# This is a Spack Environment file
+#
+# It describes a set of packages to be installed, along with
+# configuration settings.
+spack:
+  specs:
+    - mppnccombine-fast@2025.07.000
+  packages:
+    netcdf-c:
+      require:
+      - '@4.9.2'
+    hdf5:
+      require:
+      - '@1.14.2'
+    openmpi:
+      require:
+      - '@5.0.5'
+    all:
+      require:
+      - '%intel@2021.10.0'
+  view: true
+  concretizer:
+    unify: true
+  modules:
+    default:
+      tcl:
+        include:
+          - mppnccombine-fast
+        projections:
+          mppnccombine-fast: 'model-tools/{name}/2025.07.000'


### PR DESCRIPTION
This PR adds [`mppnccombine-fast`](https://github.com/ACCESS-NRI/mppnccombine-fast).

The format of the README is also updated as requested in #9 

Closes #9 

---
:rocket: The latest prerelease `mppnccombine-fast/pr10-2` at f97439fa9a20e882ca97e7c8743fa1cd157e48bb is here: https://github.com/ACCESS-NRI/model-tools/pull/10#issuecomment-3116611621 :rocket:

