### PR TITLE
Add esmf package for testing

### DIFF
--- a/esmf/spack.yaml
+++ b/esmf/spack.yaml
@@ -43,4 +43,4 @@ spack:
         include:
           - esmf
         projections:
-          esmf: 'model-tools/{name}/v8.7.0
+          esmf: 'model-tools/{name}/v8.7.0'

--- a/esmf/spack.yaml
+++ b/esmf/spack.yaml
@@ -1,0 +1,47 @@
+# This is a Spack Environment file
+#
+# It describes a set of packages to be installed, along with
+# configuration settings.
+spack:
+  specs:
+    - esmf@git.v8.7.0
+  packages:
+    packages:
+     parallelio:
+       require:
+         - '@2.6.2+pnetcdf'
+    netcdf-c:
+      require:
+        - '@4.9.2 build_system=cmake build_type=RelWithDebInfo'
+    netcdf-fortran:
+      require:
+        - '@4.6.1'
+    fms:
+      require:
+        - '@git.2024.03 precision=64 +large_file ~gfs_phys ~quad_precision ~openmp'
+    fortranxml:
+      require:
+        - '@4.1.2'
+    openmpi:
+      require:
+        - '@4.1.7'
+    gcc-runtime:
+      require:
+        - '%gcc'
+    libiconv:
+      require:
+         - '%gcc'
+     all:
+       require:
+         - '%intel@2021.10.0'
+         - 'target=x86_64_v4'
+  view: true
+  concretizer:
+    unify: true
+  modules:
+    default:
+      tcl:
+        include:
+          - esmf
+        projections:
+          esmf: 'model-tools/{name}/v8.7.0

--- a/esmf/spack.yaml
+++ b/esmf/spack.yaml
@@ -6,10 +6,9 @@ spack:
   specs:
     - esmf@git.v8.7.0
   packages:
-    packages:
-     parallelio:
-       require:
-         - '@2.6.2+pnetcdf'
+    parallelio:
+      require:
+        - '@2.6.2+pnetcdf'
     netcdf-c:
       require:
         - '@4.9.2 build_system=cmake build_type=RelWithDebInfo'
@@ -30,11 +29,11 @@ spack:
         - '%gcc'
     libiconv:
       require:
-         - '%gcc'
-     all:
-       require:
-         - '%intel@2021.10.0'
-         - 'target=x86_64_v4'
+          - '%gcc'
+    all:
+      require:
+        - '%intel@2021.10.0'
+        - 'target=x86_64_v4'
   view: true
   concretizer:
     unify: true


### PR DESCRIPTION
Proof of concept to use model-tools as a testing ground for software dependencies.

---
:rocket: The latest prerelease `esmf/pr11-1` at 990c4d8ce7955a8b95852904bcb000c0cea4f606 is here: https://github.com/ACCESS-NRI/model-tools/pull/11#issuecomment-3116653021 :rocket:


