### PR TITLE
Infra Update `v7`: `!update-configs` Comment Command

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -63,7 +63,7 @@ jobs:
       max-parallel: 1
       matrix:
         manifest: ${{ fromJson(needs.setup-cd.outputs.manifest) }}
-    uses: access-nri/build-cd/.github/workflows/cd.yml@v6
+    uses: access-nri/build-cd/.github/workflows/cd.yml@v7
     with:
       model: ${{ matrix.manifest.name }}
       spack-manifest-path: ${{ matrix.manifest.path }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
       max-parallel: 1
       matrix:
         manifest: ${{ fromJson(needs.setup-pr.outputs.manifest) }}
-    uses: access-nri/build-cd/.github/workflows/ci.yml@v6
+    uses: access-nri/build-cd/.github/workflows/ci.yml@v7
     with:
       model: ${{ matrix.manifest.name }}
       pr: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.event.issue.number }}
@@ -135,7 +135,7 @@ jobs:
       max-parallel: 1
       matrix:
         manifest: ${{ fromJson(needs.setup-pr.outputs.manifest) }}
-    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v6
+    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v7
     with:
       root-sbd: ${{ matrix.manifest.name }}
     secrets: inherit


### PR DESCRIPTION
> [!NOTE]
> SPECIAL NOTE FOR THIS REPOSITORY - this repository doesn't currently have a notion of linked configuration repositories as a normal MDR would. Therefore, the `!update-configs` command is not enabled in `ci-command.yml`. Furthermore, the `!redeploy` logic is different from other MDRs, so it isn't able to be moved out of the `ci.yml` at this time

References issue ACCESS-NRI/build-cd#320, rollout issue ACCESS-NRI/build-cd#322, and PR ACCESS-NRI/build-cd#231

> [!IMPORTANT]
> This PR is a major update to the deployment infrastructure. See below for the prerequisites for this repository to be able to merge this PR.

## Background

The `!update-configs` command is not available for this repository, as this repository doesn't have a notion of a linked configuration repository. 

## Prerequisites for Merging

- [x] Update `build-cd` entrypoints to `v7` (this PR!)
