### PR TITLE
test target=broadwell for babeltrace2

### DIFF
--- a/babeltrace2/spack.yaml
+++ b/babeltrace2/spack.yaml
@@ -5,7 +5,6 @@
 spack:
   specs:
     - babeltrace2@2.1.2
-
   packages:
     all:
       require:

--- a/babeltrace2/spack.yaml
+++ b/babeltrace2/spack.yaml
@@ -4,8 +4,7 @@
 # configuration settings.
 spack:
   specs:
-    - python@3.11
-    - babeltrace2@2.1.2 +python ^python@3.11
+    - babeltrace2@2.1.2
 
   packages:
     all:

--- a/babeltrace2/spack.yaml
+++ b/babeltrace2/spack.yaml
@@ -8,8 +8,8 @@ spack:
   packages:
     all:
       require:
-      - '%gcc@14.1.0'
-      - 'target=x86_64_v3'
+      - '%intel@2021.10.0'
+      - 'target=x86_64'
   view: true
   concretizer:
     unify: true

--- a/babeltrace2/spack.yaml
+++ b/babeltrace2/spack.yaml
@@ -9,7 +9,7 @@ spack:
     all:
       require:
       # - '%intel@2021.10.0'
-      - 'target=broadwell'
+      - 'target=x86_64_v3'
   view: true
   concretizer:
     unify: true

--- a/babeltrace2/spack.yaml
+++ b/babeltrace2/spack.yaml
@@ -8,7 +8,7 @@ spack:
   packages:
     all:
       require:
-      # - '%intel@2021.10.0'
+      - '%gcc@14.1.0'
       - 'target=x86_64_v3'
   view: true
   concretizer:

--- a/babeltrace2/spack.yaml
+++ b/babeltrace2/spack.yaml
@@ -8,7 +8,7 @@ spack:
   packages:
     all:
       require:
-      - '%intel@2021.10.0'
+      # - '%intel@2021.10.0'
       - 'target=broadwell'
   view: true
   concretizer:

--- a/babeltrace2/spack.yaml
+++ b/babeltrace2/spack.yaml
@@ -4,7 +4,9 @@
 # configuration settings.
 spack:
   specs:
-    - babeltrace2@2.1.2
+    - python@3.11
+    - babeltrace2@2.1.2 +python ^python@3.11
+
   packages:
     all:
       require:

--- a/babeltrace2/spack.yaml
+++ b/babeltrace2/spack.yaml
@@ -9,7 +9,6 @@ spack:
   packages:
     all:
       require:
-      - '%gcc@14.1.0'
       - 'target=x86_64'
   view: true
   concretizer:

--- a/babeltrace2/spack.yaml
+++ b/babeltrace2/spack.yaml
@@ -8,7 +8,9 @@ spack:
   packages:
     all:
       require:
-      - 'target=x86_64'
+      - '%intel@2021.10.0'
+      - 'target=x86_64_v4'
+      
   view: true
   concretizer:
     unify: true

--- a/babeltrace2/spack.yaml
+++ b/babeltrace2/spack.yaml
@@ -9,6 +9,7 @@ spack:
     all:
       require:
       - '%intel@2021.10.0'
+      - 'target=broadwell'
   view: true
   concretizer:
     unify: true

--- a/babeltrace2/spack.yaml
+++ b/babeltrace2/spack.yaml
@@ -8,7 +8,7 @@ spack:
   packages:
     all:
       require:
-      - '%intel@2021.10.0'
+      - '%gcc@14.1.0'
       - 'target=x86_64'
   view: true
   concretizer:

--- a/babeltrace2/spack.yaml
+++ b/babeltrace2/spack.yaml
@@ -9,8 +9,7 @@ spack:
     all:
       require:
       - '%intel@2021.10.0'
-      - 'target=x86_64_v4'
-      
+
   view: true
   concretizer:
     unify: true


### PR DESCRIPTION
`babeltrace2` currently is built targeting `x86_64_v4`, which enables AVX-512 instructions. This causes an immediate `Illegal instruction` crash when importing `bt2` on Broadwell nodes (e.g. Jupyter sessions on normalbw).

One example, 

```
> import bt2
> from pathlib import Path
> trace = Path("/scratch/tm70/ml0072/access-om3/archive/Scaling_MC-100km-ryf-MC-100km-ryf_node_1_queue_normalsr_shared_13_ocn_91-e99079ca/output000/traceout").resolve()
> it = bt2.TraceCollectionMessageIterator(str(trace))
> print("iterator created ok")
> PY
```
With Jupyter notebook on normalbw (broadwell) queue
```
Illegal instruction
```
While on the login node normal (cascade lake) queue
```
iterator created ok
```

Since Broadwell is currently the only cpu type used for ARE Jupyter, `babeltrace2` should be deployed targeting `x86_64[_v3]`, which should be (?) compatible with Broadwell while remaining fully compatible with normal and normalsr queues.

For the vk83 release environment, I've tried

- `/g/data/vk83/prerelease/apps/spack/0.22/release/linux-rocky8-x86_64_v3`,  with `@gcc-14.1.0`
- `/g/data/vk83/prerelease/apps/spack/0.22/release/linux-rocky8-x86_64`,  with `@intel-2021.10.0`

---
:rocket: The latest prerelease `babeltrace2/pr20-2` at 1d49b31267ec17c0909ba631026c5ef12401a0ef is here: https://github.com/ACCESS-NRI/model-tools/pull/20#issuecomment-3871142275 :rocket:




---
:rocket: The latest prerelease `babeltrace2/pr20-5` at 094941df1ec495ed443b83e900d91627959676e1 is here: https://github.com/ACCESS-NRI/model-tools/pull/20#issuecomment-3872409722 :rocket:




---
:rocket: The latest prerelease `babeltrace2/pr20-15` at 6acc9e87fe4484843027bf5ab2650ede4ca77938 is here: https://github.com/ACCESS-NRI/model-tools/pull/20#issuecomment-3881240518 :rocket:









