### PR TITLE
babeltrace2 based on a spack package under access-spack-packages

### DIFF
--- a/babeltrace2/spack.yaml
+++ b/babeltrace2/spack.yaml
@@ -9,6 +9,7 @@ spack:
     all:
       require:
       - '%intel@2021.10.0'
+      - 'target=x86_64'
   view: true
   concretizer:
     unify: true

--- a/babeltrace2/spack.yaml
+++ b/babeltrace2/spack.yaml
@@ -4,11 +4,11 @@
 # configuration settings.
 spack:
   specs:
-    - babeltrace2@2.1.2 %intel@2021.10.0 target=x86_64
+    - babeltrace2@2.1.2
   packages:
     all:
       require:
-      - '%intel@2021.10.0'
+      - 'target=x86_64'
   view: true
   concretizer:
     unify: true

--- a/babeltrace2/spack.yaml
+++ b/babeltrace2/spack.yaml
@@ -8,7 +8,7 @@ spack:
   packages:
     all:
       require:
-      - 'target=x86_64_v4'
+      - '%intel@2021.10.0'
   view: true
   concretizer:
     unify: true

--- a/babeltrace2/spack.yaml
+++ b/babeltrace2/spack.yaml
@@ -4,12 +4,11 @@
 # configuration settings.
 spack:
   specs:
-    - babeltrace2@2.1.2
+    - babeltrace2@2.1.2 %intel@2021.10.0 target=x86_64
   packages:
     all:
       require:
       - '%intel@2021.10.0'
-      - 'target=x86_64'
   view: true
   concretizer:
     unify: true

--- a/babeltrace2/spack.yaml
+++ b/babeltrace2/spack.yaml
@@ -8,7 +8,7 @@ spack:
   packages:
     all:
       require:
-      - 'target=x86_64'
+      - 'target=x86_64_v4'
   view: true
   concretizer:
     unify: true
@@ -19,4 +19,3 @@ spack:
           - babeltrace2
         projections:
           babeltrace2: 'model-tools/{name}/2.1.2'
-  

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.09.004"
+    "spack-packages": "babeltrace2-test"
 }


### PR DESCRIPTION
TEST ONLY

---
:rocket: The latest prerelease `babeltrace2/pr21-6` at a2b92f8e570c3d1a6d8eca90a3632803bf0a622c is here: https://github.com/ACCESS-NRI/model-tools/pull/21#issuecomment-3878609003 :rocket:





