### PR TITLE
Update all projections to include `{version}`

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ To load the most recent version of `fre-nctools`:
 module load model-tools/fre-nctools
 ```
 
+## Development
+
+How this repository is developed is essentially in line with `ACCESS-NRI/software-deployment-template`, but with the caveat that we use the `model-tools` prefix in the module projections, to note it is a supplemental tool rather than a model itself.
+
 ## Support
 
 This repository and the software deployed from it are supported by ACCESS-NRI.

--- a/babeltrace2/spack.yaml
+++ b/babeltrace2/spack.yaml
@@ -33,4 +33,4 @@ spack:
         - babeltrace2
         projections:
           # build-cd will inject the _version into this projection
-          babeltrace2: 'model-tools/{name}'
+          babeltrace2: 'model-tools/{name}/{version}'

--- a/esmf/spack.yaml
+++ b/esmf/spack.yaml
@@ -63,4 +63,4 @@ spack:
         - fortranxml
         projections:
           # build-cd will inject the _version into this projection
-          esmf: 'model-tools/{name}'
+          esmf: 'model-tools/{name}/{version}'

--- a/fre-nctools/spack.yaml
+++ b/fre-nctools/spack.yaml
@@ -39,4 +39,4 @@ spack:
         - fre-nctools
         projections:
           # build-cd will inject the _version into this projection
-          fre-nctools: 'model-tools/{name}'
+          fre-nctools: 'model-tools/{name}/{version}'

--- a/mppnccombine-fast/spack.yaml
+++ b/mppnccombine-fast/spack.yaml
@@ -42,4 +42,4 @@ spack:
         - mppnccombine-fast
         projections:
           # build-cd will inject the _version into this projection
-          mppnccombine-fast: 'model-tools/{name}'
+          mppnccombine-fast: 'model-tools/{name}/{version}'


### PR DESCRIPTION
## Background

Pre- https://github.com/ACCESS-NRI/build-cd/pull/382, the projection injection logic injected the reserved definition `_version` into the projection. This was a bit convoluted, and difficult to understand for users. In the linked PR, we have updated that logic to instead inject `{version}` with `_version` for things in the speclist. 

## The PR

* Update all `*/spack.yaml` to include `{version}` in the projection.
