### PR TITLE
Change compiler to oneapi and target to x86_64_v3

### DIFF
--- a/babeltrace2/spack.yaml
+++ b/babeltrace2/spack.yaml
@@ -40,6 +40,11 @@ spack:
       git: https://github.com/ACCESS-NRI/access-spack-packages.git
       tag: 2026.08.008
       destination: $env/package-repos/access-spack-packages
+    # Remove `builtin` once the babeltrace fix is in `access/v1.1` branch
+    #builtin:
+    #  git: https://github.com/ACCESS-NRI/upstream-spack-packages.git
+    #  branch: access/v1.1-next
+    #  destination: $env/package-repos/upstream-spack-packages
   modules:
     default:
       tcl:

--- a/babeltrace2/spack.yaml
+++ b/babeltrace2/spack.yaml
@@ -18,15 +18,15 @@ spack:
     # Compilers
     c:
       require:
-      - intel-oneapi-compilers-classic@2021.10.0
+      - intel-oneapi-compilers@2025.2.0
 
     cxx:
       require:
-      - intel-oneapi-compilers-classic@2021.10.0
+      - intel-oneapi-compilers@2025.2.0
 
     fortran:
       require:
-      - intel-oneapi-compilers-classic@2021.10.0
+      - intel-oneapi-compilers@2025.2.0
 
     all:
       prefer:

--- a/babeltrace2/spack.yaml
+++ b/babeltrace2/spack.yaml
@@ -16,11 +16,6 @@ spack:
   - babeltrace2@2.1.2
 
   packages:
-    tar:
-      externals:
-      - spec: tar@1.30
-        prefix: /usr/bin
-      buildable: false
     # Compilers
     c:
       require:
@@ -46,11 +41,6 @@ spack:
       git: https://github.com/ACCESS-NRI/access-spack-packages.git
       tag: 2026.08.008
       destination: $env/package-repos/access-spack-packages
-    # Remove `builtin` once the babeltrace fix is in `access/v1.1` branch
-    builtin:
-      git: https://github.com/ACCESS-NRI/upstream-spack-packages.git
-      branch: access/v1.1-next
-      destination: $env/package-repos/upstream-spack-packages
   modules:
     default:
       tcl:

--- a/babeltrace2/spack.yaml
+++ b/babeltrace2/spack.yaml
@@ -14,7 +14,13 @@ spack:
   - _injection: []
   specs:
   - babeltrace2@2.1.2
+
   packages:
+    tar:
+      externals:
+      - spec: tar@1.30
+        prefix: /usr/bin
+      buildable: false
     # Compilers
     c:
       require:

--- a/babeltrace2/spack.yaml
+++ b/babeltrace2/spack.yaml
@@ -47,10 +47,10 @@ spack:
       tag: 2026.08.008
       destination: $env/package-repos/access-spack-packages
     # Remove `builtin` once the babeltrace fix is in `access/v1.1` branch
-    #builtin:
-    #  git: https://github.com/ACCESS-NRI/upstream-spack-packages.git
-    #  branch: access/v1.1-next
-    #  destination: $env/package-repos/upstream-spack-packages
+    builtin:
+      git: https://github.com/ACCESS-NRI/upstream-spack-packages.git
+      branch: access/v1.1-next
+      destination: $env/package-repos/upstream-spack-packages
   modules:
     default:
       tcl:

--- a/babeltrace2/spack.yaml
+++ b/babeltrace2/spack.yaml
@@ -28,13 +28,17 @@ spack:
       require:
       - intel-oneapi-compilers-classic@2021.10.0
 
+    all:
+      prefer:
+      - target=x86_64_v3
+
   view: true
   concretizer:
     unify: true
   repos:
     access_spack_packages:
       git: https://github.com/ACCESS-NRI/access-spack-packages.git
-      tag: 2026.02.002
+      tag: 2026.08.008
       destination: $env/package-repos/access-spack-packages
   modules:
     default:

--- a/babeltrace2/spack.yaml
+++ b/babeltrace2/spack.yaml
@@ -6,7 +6,7 @@ spack:
   definitions:
   # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
   - _name: [babeltrace2]
-  - _version: [2.1.2-1]
+  - _version: [2.1.2-2]
   # _spack-version informs the branch of spack to use
   - _spack-version: ["1.1"]
   # Release database provenance information - packages for inclusion into the database, and packages just for injection into the modules

--- a/babeltrace2/spack.yaml
+++ b/babeltrace2/spack.yaml
@@ -46,6 +46,7 @@ spack:
       tcl:
         include:
         - babeltrace2
+        - python
         projections:
           # build-cd will inject the _version into this projection
           babeltrace2: 'model-tools/{name}/{version}'


### PR DESCRIPTION
Spack v1.1 test of https://github.com/ACCESS-NRI/model-tools/pull/20

This PR requires: https://github.com/ACCESS-NRI/upstream-spack-packages/pull/7

---
:rocket: The latest prerelease `babeltrace2/pr24-8` at 1d4640897eb446e925ae6b693f05430cc4d1bb47 is here: https://github.com/ACCESS-NRI/model-tools/pull/24#issuecomment-5389987331 :rocket:









---
:rocket: The latest prerelease `babeltrace2/pr24-11` at 81cd1c78d7852a9870d0b1ae4cc4d28cbf43b097 is here: https://github.com/ACCESS-NRI/model-tools/pull/24#issuecomment-5413235218 :rocket:



