### PR TITLE
Infra Update `v9`: Consolidate Config Into Manifest

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - main
     paths:
-      - config/**
       - '**/spack.yaml'
 jobs:
     # FIXME: For now, this modified workflow does not deploy based on changes to the config/** files.
@@ -63,13 +62,11 @@ jobs:
       max-parallel: 1
       matrix:
         manifest: ${{ fromJson(needs.setup-cd.outputs.manifest) }}
-    uses: access-nri/build-cd/.github/workflows/cd.yml@v8
+    uses: access-nri/build-cd/.github/workflows/cd.yml@v9
     with:
       model: ${{ matrix.manifest.name }}
       spack-manifest-path: ${{ matrix.manifest.path }}
       spack-manifest-schema-version: 2-0-0
-      config-versions-schema-version: 4-0-0
-      config-packages-schema-version: 1-0-0
       # This is a non-model deployment repository, so we do not want to tag the deployment or upload to the build database
       tag-deployment: false
       upload-to-build-db: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ on:
       - dev
       - backport/*.*
     paths:
-      - config/**
       - '**/spack.yaml'
   issue_comment:
     types:
@@ -105,13 +104,11 @@ jobs:
       max-parallel: 1
       matrix:
         manifest: ${{ fromJson(needs.setup-pr.outputs.manifest) }}
-    uses: access-nri/build-cd/.github/workflows/ci.yml@v8
+    uses: access-nri/build-cd/.github/workflows/ci.yml@v9
     with:
       model: ${{ matrix.manifest.name }}
       spack-manifest-path: ${{ matrix.manifest.path }}
       spack-manifest-schema-version: 2-0-0
-      config-versions-schema-version: 4-0-0
-      config-packages-schema-version: 1-0-0
     permissions:
       pull-requests: write
       contents: write
@@ -132,7 +129,7 @@ jobs:
       max-parallel: 1
       matrix:
         manifest: ${{ fromJson(needs.setup-pr.outputs.manifest) }}
-    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v8
+    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v9
     with:
       spack-manifest-path: ${{ matrix.manifest.path }}
     secrets: inherit

--- a/babeltrace2/spack.yaml
+++ b/babeltrace2/spack.yaml
@@ -35,7 +35,7 @@ spack:
     access_spack_packages:
       git: https://github.com/ACCESS-NRI/access-spack-packages.git
       tag: 2026.02.002
-      destination: $env/.package_repos/access-spack-packages
+      destination: $env/package-repos/access-spack-packages
   modules:
     default:
       tcl:

--- a/babeltrace2/spack.yaml
+++ b/babeltrace2/spack.yaml
@@ -7,6 +7,11 @@ spack:
   # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
   - _name: [babeltrace2]
   - _version: [2.1.2-1]
+  # _spack-version informs the branch of spack to use
+  - _spack-version: ["1.1"]
+  # Release database provenance information - packages for inclusion into the database, and packages just for injection into the modules
+  - _provenance: []
+  - _injection: []
   specs:
   - babeltrace2@2.1.2
   packages:
@@ -26,6 +31,11 @@ spack:
   view: true
   concretizer:
     unify: true
+  repos:
+    access_spack_packages:
+      git: https://github.com/ACCESS-NRI/access-spack-packages.git
+      tag: 2026.02.002
+      destination: $env/.package_repos/access-spack-packages
   modules:
     default:
       tcl:

--- a/config/packages.json
+++ b/config/packages.json
@@ -1,5 +1,0 @@
-{
-  "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/packages/1-0-0.json",
-  "provenance": [],
-  "injection": []
-}

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,0 @@
-{
-  "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
-  "spack": "1.1",
-  "access-spack-packages": "2026.02.002"
-}

--- a/esmf/spack.yaml
+++ b/esmf/spack.yaml
@@ -7,6 +7,11 @@ spack:
   # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
   - _name: [esmf]
   - _version: [v8.7.0-1]
+  # _spack-version informs the branch of spack to use
+  - _spack-version: ["1.1"]
+  # Release database provenance information - packages for inclusion into the database, and packages just for injection into the modules
+  - _provenance: []
+  - _injection: []
   specs:
   - esmf@git.v8.7.0
   packages:
@@ -51,6 +56,11 @@ spack:
   view: true
   concretizer:
     unify: true
+  repos:
+    access_spack_packages:
+      git: https://github.com/ACCESS-NRI/access-spack-packages.git
+      tag: 2026.02.002
+      destination: $env/.package_repos/access-spack-packages
   modules:
     default:
       tcl:

--- a/esmf/spack.yaml
+++ b/esmf/spack.yaml
@@ -60,7 +60,7 @@ spack:
     access_spack_packages:
       git: https://github.com/ACCESS-NRI/access-spack-packages.git
       tag: 2026.02.002
-      destination: $env/.package_repos/access-spack-packages
+      destination: $env/package-repos/access-spack-packages
   modules:
     default:
       tcl:

--- a/fre-nctools/spack.yaml
+++ b/fre-nctools/spack.yaml
@@ -7,6 +7,11 @@ spack:
   # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
   - _name: [fre-nctools]
   - _version: [2024.05-1]
+  # _spack-version informs the branch of spack to use
+  - _spack-version: ["1.1"]
+  # Release database provenance information - packages for inclusion into the database, and packages just for injection into the modules
+  - _provenance: []
+  - _injection: []
   specs:
   - fre-nctools@2024.05-1
   packages:
@@ -32,6 +37,11 @@ spack:
   view: true
   concretizer:
     unify: true
+  repos:
+    access_spack_packages:
+      git: https://github.com/ACCESS-NRI/access-spack-packages.git
+      tag: 2026.02.002
+      destination: $env/.package_repos/access-spack-packages
   modules:
     default:
       tcl:

--- a/fre-nctools/spack.yaml
+++ b/fre-nctools/spack.yaml
@@ -41,7 +41,7 @@ spack:
     access_spack_packages:
       git: https://github.com/ACCESS-NRI/access-spack-packages.git
       tag: 2026.02.002
-      destination: $env/.package_repos/access-spack-packages
+      destination: $env/package-repos/access-spack-packages
   modules:
     default:
       tcl:

--- a/mppnccombine-fast/spack.yaml
+++ b/mppnccombine-fast/spack.yaml
@@ -7,6 +7,11 @@ spack:
   # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
   - _name: [mppnccombine-fast]
   - _version: [2025.07.000-1]
+  # _spack-version informs the branch of spack to use
+  - _spack-version: ["1.1"]
+  # Release database provenance information - packages for inclusion into the database, and packages just for injection into the modules
+  - _provenance: []
+  - _injection: []
   specs:
   - mppnccombine-fast@2025.07.000
   packages:
@@ -35,6 +40,11 @@ spack:
   view: true
   concretizer:
     unify: true
+  repos:
+    access_spack_packages:
+      git: https://github.com/ACCESS-NRI/access-spack-packages.git
+      tag: 2026.02.002
+      destination: $env/.package_repos/access-spack-packages
   modules:
     default:
       tcl:

--- a/mppnccombine-fast/spack.yaml
+++ b/mppnccombine-fast/spack.yaml
@@ -44,7 +44,7 @@ spack:
     access_spack_packages:
       git: https://github.com/ACCESS-NRI/access-spack-packages.git
       tag: 2026.02.002
-      destination: $env/.package_repos/access-spack-packages
+      destination: $env/package-repos/access-spack-packages
   modules:
     default:
       tcl:


### PR DESCRIPTION
Closes #26

References ACCESS-NRI/build-cd#404

> [!IMPORTANT]
> This is a major update to the deployment infrastructure. Open PRs should be rebased once this is merged.

## Background

We have moved to `spack v1.1`, which has a bunch of cool features that allow us to take a bit of strain off the infrastructure by letting spack handle things like cloning git-based spack package repositories as opposed to the infra having to do it. 
While we were at it, we moved as much of the `config/*.json` files into the manifest as Reserved Definitions (`spack.definitions` that have a `_` prepended, like `_name` and `_version`), just so it was all in the one file. 
Finally, I have removed a unnneeded `model` input from the `!update-configs` entrypoint workflow, so it's a bit cleaner.
## What you 🫵 need to know

* You now specify the `access-spack-packages` version in the `spack.yaml`, under the `spack.repos.access_spack_packages` key, giving it either a `commit:`, `branch:` or `tag:`. Keep the `destination:` as it is - it will aid the infra in cleanup after!
* Similarly, you now specify the spack version, custom scopes, packages for provenance and packages for injection as reserved definitions at the top of the `spack.yaml` file. 

## The PR

* Bump entrypoint workflows to `v9`, remove unneeded inputs, updated `spack.yaml` schema version
* Move config from `config/` into `spack.yaml`s, delete those files

